### PR TITLE
[refactor] 完成button、tag自定义组件改造

### DIFF
--- a/example/pages/btn/index.json
+++ b/example/pages/btn/index.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "Button 按钮"
+  "navigationBarTitleText": "Button 按钮",
+  "usingComponents": {
+    "zan-button": "/dist/btn/index"
+  }
 }

--- a/example/pages/btn/index.wxml
+++ b/example/pages/btn/index.wxml
@@ -5,40 +5,69 @@
   <view class="zan-panel-title">普通按钮</view>
   <view class="zan-panel">
     <view class="zan-btns">
+      <zan-button>取消订单</zan-button>
       <button class="zan-btn">取消订单</button>
+
+      <zan-button type="primary">确认付款</zan-button>
       <button class="zan-btn zan-btn--primary">确认付款</button>
+
+      <zan-button type="danger">确认付款</zan-button>
       <button class="zan-btn zan-btn--danger">确认付款</button>
+
+      <zan-button type="warn">确认付款</zan-button>
       <button class="zan-btn zan-btn--warn">确认付款</button>
     </view>
   </view>
 
   <view class="zan-panel-title">大号按钮，没有边框线及圆角</view>
   <view class="zan-panel">
+    <zan-button size="large" type="primary">确认付款</zan-button>
     <button class="zan-btn zan-btn--large zan-btn--primary">确认付款</button>
+
+    <zan-button size="large" type="warn">立即购买</zan-button>
     <button class="zan-btn zan-btn--large zan-btn--warn">立即购买</button>
+
+    <zan-button size="large" type="danger">立即购买</zan-button>
     <button class="zan-btn zan-btn--large zan-btn--danger">立即购买</button>
   </view>
 
   <view class="zan-panel-title">小号按钮</view>
   <view class="zan-panel" style="padding: 15px;">
+    <zan-button size="small">取消订单</zan-button>
     <button class="zan-btn zan-btn--small">取消订单</button>
+
+    <zan-button size="small" type="primary">确认付款</zan-button>
     <button class="zan-btn zan-btn--small zan-btn--primary">确认付款</button>
   </view>
 
   <view class="zan-panel-title">迷你按钮</view>
   <view class="zan-panel" style="padding: 15px;">
+    <zan-button size="mini">取消订单</zan-button>
     <button class="zan-btn zan-btn--mini zan-btn--plain">取消订单</button>
+
+    <zan-button size="mini" type="primary">确认付款</zan-button>
     <button class="zan-btn zan-btn--mini zan-btn--primary zan-btn--plain">确认付款</button>
+
+    <zan-button size="mini" type="warn">确认付款</zan-button>
     <button class="zan-btn zan-btn--mini zan-btn--warn zan-btn--plain">确认付款</button>
+
+    <zan-button size="mini" type="danger">确认付款</zan-button>
     <button class="zan-btn zan-btn--mini zan-btn--danger zan-btn--plain">确认付款</button>
   </view>
 
   <view class="zan-panel-title">Loading</view>
   <view class="zan-panel">
     <view class="zan-btns">
+      <zan-button loading>取消订单</zan-button>
       <button class="zan-btn zan-btn--loading">取消订单</button>
+
+      <zan-button loading type="primary">确认付款</zan-button>
       <button class="zan-btn zan-btn--loading zan-btn--primary">确认付款</button>
+
+      <zan-button loading type="danger">确认付款</zan-button>
       <button class="zan-btn zan-btn--loading zan-btn--danger">确认付款</button>
+
+      <zan-button loading type="warn">确认付款</zan-button>
       <button class="zan-btn zan-btn--loading zan-btn--warn">确认付款</button>
     </view>
   </view>
@@ -46,9 +75,16 @@
   <view class="zan-panel-title">Disabled</view>
   <view class="zan-panel">
     <view class="zan-btns">
+      <zan-button disabled>取消订单</zan-button>
       <button class="zan-btn zan-btn--disabled" disabled>取消订单</button>
+
+      <zan-button disabled type="primary">确认付款</zan-button>
       <button class="zan-btn zan-btn--disabled zan-btn--primary" disabled>确认付款</button>
+
+      <zan-button disabled type="danger">确认付款</zan-button>
       <button class="zan-btn zan-btn--disabled zan-btn--danger" disabled>确认付款</button>
+
+      <zan-button disabled type="warn">确认付款</zan-button>
       <button class="zan-btn zan-btn--disabled zan-btn--warn" disabled>确认付款</button>
     </view>
   </view>

--- a/example/pages/btn/index.wxml
+++ b/example/pages/btn/index.wxml
@@ -6,69 +6,40 @@
   <view class="zan-panel">
     <view class="zan-btns">
       <zan-button>取消订单</zan-button>
-      <button class="zan-btn">取消订单</button>
-
       <zan-button type="primary">确认付款</zan-button>
-      <button class="zan-btn zan-btn--primary">确认付款</button>
-
       <zan-button type="danger">确认付款</zan-button>
-      <button class="zan-btn zan-btn--danger">确认付款</button>
-
       <zan-button type="warn">确认付款</zan-button>
-      <button class="zan-btn zan-btn--warn">确认付款</button>
     </view>
   </view>
 
   <view class="zan-panel-title">大号按钮，没有边框线及圆角</view>
   <view class="zan-panel">
     <zan-button size="large" type="primary">确认付款</zan-button>
-    <button class="zan-btn zan-btn--large zan-btn--primary">确认付款</button>
-
     <zan-button size="large" type="warn">立即购买</zan-button>
-    <button class="zan-btn zan-btn--large zan-btn--warn">立即购买</button>
-
     <zan-button size="large" type="danger">立即购买</zan-button>
-    <button class="zan-btn zan-btn--large zan-btn--danger">立即购买</button>
   </view>
 
   <view class="zan-panel-title">小号按钮</view>
   <view class="zan-panel" style="padding: 15px;">
     <zan-button size="small">取消订单</zan-button>
-    <button class="zan-btn zan-btn--small">取消订单</button>
-
     <zan-button size="small" type="primary">确认付款</zan-button>
-    <button class="zan-btn zan-btn--small zan-btn--primary">确认付款</button>
   </view>
 
   <view class="zan-panel-title">迷你按钮</view>
   <view class="zan-panel" style="padding: 15px;">
     <zan-button size="mini">取消订单</zan-button>
-    <button class="zan-btn zan-btn--mini zan-btn--plain">取消订单</button>
-
     <zan-button size="mini" type="primary">确认付款</zan-button>
-    <button class="zan-btn zan-btn--mini zan-btn--primary zan-btn--plain">确认付款</button>
-
     <zan-button size="mini" type="warn">确认付款</zan-button>
-    <button class="zan-btn zan-btn--mini zan-btn--warn zan-btn--plain">确认付款</button>
-
     <zan-button size="mini" type="danger">确认付款</zan-button>
-    <button class="zan-btn zan-btn--mini zan-btn--danger zan-btn--plain">确认付款</button>
   </view>
 
   <view class="zan-panel-title">Loading</view>
   <view class="zan-panel">
     <view class="zan-btns">
       <zan-button loading>取消订单</zan-button>
-      <button class="zan-btn zan-btn--loading">取消订单</button>
-
       <zan-button loading type="primary">确认付款</zan-button>
-      <button class="zan-btn zan-btn--loading zan-btn--primary">确认付款</button>
-
       <zan-button loading type="danger">确认付款</zan-button>
-      <button class="zan-btn zan-btn--loading zan-btn--danger">确认付款</button>
-
       <zan-button loading type="warn">确认付款</zan-button>
-      <button class="zan-btn zan-btn--loading zan-btn--warn">确认付款</button>
     </view>
   </view>
 
@@ -76,16 +47,9 @@
   <view class="zan-panel">
     <view class="zan-btns">
       <zan-button disabled>取消订单</zan-button>
-      <button class="zan-btn zan-btn--disabled" disabled>取消订单</button>
-
       <zan-button disabled type="primary">确认付款</zan-button>
-      <button class="zan-btn zan-btn--disabled zan-btn--primary" disabled>确认付款</button>
-
       <zan-button disabled type="danger">确认付款</zan-button>
-      <button class="zan-btn zan-btn--disabled zan-btn--danger" disabled>确认付款</button>
-
       <zan-button disabled type="warn">确认付款</zan-button>
-      <button class="zan-btn zan-btn--disabled zan-btn--warn" disabled>确认付款</button>
     </view>
   </view>
 

--- a/example/pages/tag/index.json
+++ b/example/pages/tag/index.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "Tag 标记"
+  "navigationBarTitleText": "Tag 标记",
+  "usingComponents": {
+    "zan-tag": "/dist/tag/index"
+  }
 }

--- a/example/pages/tag/index.wxml
+++ b/example/pages/tag/index.wxml
@@ -4,27 +4,27 @@
 
   <view class="zan-panel">
     <view class="zan-cell zan-cell--last-child">
-      <view class="zan-tag">灰色</view>
-      <view class="zan-tag zan-tag--danger">红色</view>
-      <view class="zan-tag zan-tag--disabled">不可用</view>
+      <zan-tag>灰色</zan-tag>
+      <zan-tag type="danger">红色</zan-tag>
+      <zan-tag disabled>不可用</zan-tag>
     </view>
   </view>
   <view class="zan-panel">
     <view class="zan-cell zan-cell--last-child">
-      <view class="zan-tag zan-tag--danger">会员折扣</view>
-      <view class="zan-tag zan-tag--warn">返现</view>
-      <view class="zan-tag zan-tag--primary">返现</view>
-      <view class="zan-tag zan-tag--primary zan-tag--disabled">不可用</view>
+      <zan-tag type="danger">会员折扣</zan-tag>
+      <zan-tag type="warn">返现</zan-tag>
+      <zan-tag type="primary">返现</zan-tag>
+      <zan-tag type="primary" disabled>不可用</zan-tag>
     </view>
   </view>
 
     <view class="zan-panel">
     <view class="zan-cell zan-cell--last-child">
-      <view class="zan-tag zan-tag--plain">灰色</view>
-      <view class="zan-tag zan-tag--danger zan-tag--plain">会员折扣</view>
-      <view class="zan-tag zan-tag--warn zan-tag--plain">返现</view>
-      <view class="zan-tag zan-tag--primary zan-tag--plain">返现</view>
-      <view class="zan-tag zan-tag--primary zan-tag--plain zan-tag--disabled">返现不可用</view>
+      <zan-tag plain>灰色</zan-tag>
+      <zan-tag type="danger" plain>会员折扣</zan-tag>
+      <zan-tag type="warn" plain>返现</zan-tag>
+      <zan-tag type="primary" plain>返现</zan-tag>
+      <zan-tag type="primary" plain disabled>返现不可用</zan-tag>
     </view>
   </view>
 </view>

--- a/example/pages/tag/index.wxss
+++ b/example/pages/tag/index.wxss
@@ -1,3 +1,3 @@
-.zan-tag + .zan-tag {
+zan-tag + zan-tag {
   margin-left: 10px;
 }

--- a/packages/btn/index.js
+++ b/packages/btn/index.js
@@ -1,21 +1,22 @@
 
 Component({
-    properties: {
-        type: {
-            type: String,
-            value: '',
-        },
-        size: {
-            type: String,
-            value: '',
-        },
-        disabled: {
-            type: Boolean,
-            value: false,
-        },
-        loading: {
-            type: Boolean,
-            value: false,
-        },
+  externalClasses: ['custom-class'],
+  properties: {
+    type: {
+      type: String,
+      value: '',
     },
+    size: {
+      type: String,
+      value: '',
+    },
+    disabled: {
+      type: Boolean,
+      value: false,
+    },
+    loading: {
+      type: Boolean,
+      value: false,
+    },
+  },
 });

--- a/packages/btn/index.js
+++ b/packages/btn/index.js
@@ -1,0 +1,21 @@
+
+Component({
+    properties: {
+        type: {
+            type: String,
+            value: '',
+        },
+        size: {
+            type: String,
+            value: '',
+        },
+        disabled: {
+            type: Boolean,
+            value: false,
+        },
+        loading: {
+            type: Boolean,
+            value: false,
+        },
+    },
+});

--- a/packages/btn/index.json
+++ b/packages/btn/index.json
@@ -1,0 +1,3 @@
+{
+    "component": true
+}

--- a/packages/btn/index.json
+++ b/packages/btn/index.json
@@ -1,3 +1,3 @@
 {
-    "component": true
+  "component": true
 }

--- a/packages/btn/index.pcss
+++ b/packages/btn/index.pcss
@@ -150,9 +150,5 @@
 }
 
 /* :last-child */
-.zan-btn--last-child,
-.zan-btn:last-child {
-  margin-bottom: 0;
-  margin-right: 0;
-}
+
 

--- a/packages/btn/index.wxml
+++ b/packages/btn/index.wxml
@@ -1,7 +1,7 @@
 
 <button 
-    class="zan-btn {{size ? 'zan-btn--'+size : ''}} {{size == 'mini' ? 'zan-btn--plain' : ''}} {{type ? 'zan-btn--'+type : ''}} {{loading ? 'zan-btn--loading' : ''}} {{disabled ? 'zan-btn--disabled' : ''}}"
-    disabled="{{disabled}}"
+  class="custom-class zan-btn {{size ? 'zan-btn--'+size : ''}} {{size === 'mini' ? 'zan-btn--plain' : ''}} {{type ? 'zan-btn--'+type : ''}} {{loading ? 'zan-btn--loading' : ''}} {{disabled ? 'zan-btn--disabled' : ''}}"
+  disabled="{{disabled}}"
 >
-    <slot></slot>
+  <slot></slot>
 </button>

--- a/packages/btn/index.wxml
+++ b/packages/btn/index.wxml
@@ -1,0 +1,7 @@
+
+<button 
+    class="zan-btn {{size ? 'zan-btn--'+size : ''}} {{size == 'mini' ? 'zan-btn--plain' : ''}} {{type ? 'zan-btn--'+type : ''}} {{loading ? 'zan-btn--loading' : ''}} {{disabled ? 'zan-btn--disabled' : ''}}"
+    disabled="{{disabled}}"
+>
+    <slot></slot>
+</button>

--- a/packages/tag/index.js
+++ b/packages/tag/index.js
@@ -1,0 +1,15 @@
+Component({
+    properties: {
+        type: {
+            type: String,
+        },
+        plain: {
+            type: Boolean,
+            value: false,
+        },
+        disabled: {
+            type: Boolean,
+            value: false,
+        }
+    }
+});

--- a/packages/tag/index.js
+++ b/packages/tag/index.js
@@ -1,15 +1,15 @@
 Component({
-    properties: {
-        type: {
-            type: String,
-        },
-        plain: {
-            type: Boolean,
-            value: false,
-        },
-        disabled: {
-            type: Boolean,
-            value: false,
-        }
+  properties: {
+    type: {
+      type: String,
+    },
+    plain: {
+      type: Boolean,
+      value: false,
+    },
+    disabled: {
+      type: Boolean,
+      value: false,
     }
+  }
 });

--- a/packages/tag/index.json
+++ b/packages/tag/index.json
@@ -1,0 +1,3 @@
+{
+    "component": true
+}

--- a/packages/tag/index.json
+++ b/packages/tag/index.json
@@ -1,3 +1,3 @@
 {
-    "component": true
+  "component": true
 }

--- a/packages/tag/index.wxml
+++ b/packages/tag/index.wxml
@@ -1,6 +1,6 @@
 
 <view 
-    class="zan-tag {{type ? 'zan-tag--'+type : ''}} {{disabled ? 'zan-tag--disabled' : ''}} {{plain ? 'zan-tag--plain' : ''}}"
+  class="zan-tag {{type ? 'zan-tag--'+type : ''}} {{disabled ? 'zan-tag--disabled' : ''}} {{plain ? 'zan-tag--plain' : ''}}"
 >
-    <slot></slot>
+  <slot></slot>
 </view>

--- a/packages/tag/index.wxml
+++ b/packages/tag/index.wxml
@@ -1,0 +1,6 @@
+
+<view 
+    class="zan-tag {{type ? 'zan-tag--'+type : ''}} {{disabled ? 'zan-tag--disabled' : ''}} {{plain ? 'zan-tag--plain' : ''}}"
+>
+    <slot></slot>
+</view>


### PR DESCRIPTION
* [breaking change] zan-tag: 改为微信自定义组件
* [breaking change] zan-button: 改为微信自定义组件

pull request 改动点:

- tag改为微信自定义组件，可通过属性type、plain、disabled来控制显示样式
- button改为微信自定义组件，可通过属性type、size、disabled、loading来控制显示样式