### PR TITLE
[bugfix] Switch：修复组件示例名称错误

### DIFF
--- a/example/pages/switch/index.wxml
+++ b/example/pages/switch/index.wxml
@@ -6,7 +6,7 @@
     </zan-cell>
   </zan-panel>
 
-  <zan-panel title='同步开关'>
+  <zan-panel title='异步开关'>
     <zan-cell>
       <zan-switch checked="{{async.checked}}" disabled="{{ async.disabled }}" loading="{{ async.loading }}" bind:change="asyncChange" />
     </zan-cell>


### PR DESCRIPTION
pull request 改动点:

- 修复示例中，关于异步 ```Switch```组件 的名称错误
