### PR TITLE
fixed when step is a decimals sometimes

### DIFF
--- a/packages/stepper/index.js
+++ b/packages/stepper/index.js
@@ -37,6 +37,8 @@ Component({
       } else if (type === 'plus') {
         stepper += step;
       }
+      
+      if (stepper <= this.data.min || stepper >= this.data.max) return null;
 
       this.triggerEvent('change', stepper);
       this.triggerEvent(type);

--- a/packages/stepper/index.js
+++ b/packages/stepper/index.js
@@ -38,7 +38,7 @@ Component({
         stepper += step;
       }
       
-      if (stepper <= this.data.min || stepper >= this.data.max) return null;
+      if (stepper < this.data.min || stepper > this.data.max) return null;
 
       this.triggerEvent('change', stepper);
       this.triggerEvent(type);


### PR DESCRIPTION
case:
html
```html
<zan-stepper stepper="{{ value }}" min="0" max="100" step="0.2" bindchange="handleChange" />
```
js
```js
Page({
    data: {
        value: 0.1
    },

    handleChange...
});
```