### PR TITLE
[bugfix] Doc: Card 示例页 title 标注错误为 CAPSULE

### DIFF
--- a/example/components/doc-page/index.wxml
+++ b/example/components/doc-page/index.wxml
@@ -1,5 +1,11 @@
+<wxs module="filter">
+  module.exports.toUpperCase = function(v) {
+    return v.toUpperCase();
+  }
+</wxs>
+
 <view class="doc-container">
-  <view class="doc-title">{{ title }}</view>
+  <view class="doc-title">{{ filter.toUpperCase(title) }}</view>
   <view class="doc-content {{ withoutPadding ? 'doc-content--without-pd' : '' }}">
     <slot></slot>
   </view>

--- a/example/pages/card/index.wxml
+++ b/example/pages/card/index.wxml
@@ -1,4 +1,4 @@
-<doc-page title="CAPSULE" without-padding>
+<doc-page title="CARD" without-padding>
 
   <zan-panel without-border>
     <zan-card


### PR DESCRIPTION
pull request 改动点:

- [bugfix] Doc: Card 示例页 title 标注错误为 CAPSULE
- [improvement] Doc: 统一 title 为大写
 